### PR TITLE
feat: support host UID/GID mapping for container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM python:3.12-alpine
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-RUN apk add --no-cache tzdata ca-certificates cronie ffmpeg
+RUN apk add --no-cache tzdata ca-certificates cronie ffmpeg su-exec
 RUN pip install --no-cache-dir svtplay-dl
+
+RUN addgroup -g "$GROUP_ID" -S svtplay \
+ && adduser -u "$USER_ID" -S -G svtplay -h /home/svtplay -s /bin/sh svtplay
+
+RUN mkdir -p /downloads /var/log && chown -R svtplay:svtplay /downloads /var/log
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY download.sh /usr/local/bin/download.sh
@@ -14,6 +21,6 @@ VOLUME ["/downloads"]
 
 ENV OUTPUT_DIR=/downloads
 ENV CRON_SCHEDULE="0 3 * * *"
-ENV SVTPLAY_DL_URLS=""
+ENV SVTPLAY_DL_COMMANDS=""
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -34,17 +34,24 @@ docker run --rm \
 
 If `SVTPLAY_DL_COMMANDS` is set, it is used for downloads.
 
-Example:
+For bind mounts and file ownership, this image supports building a container user with host UID/GID:
 
 ```yaml
 services:
   svtplay-dl:
-    image: docker-svtplay-dl:latest
+    build:
+      context: .
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
     environment:
       SVTPLAY_DL_COMMANDS: |
         svtplay-dl --only-video -o /downloads https://www.svtplay.se/video/...
         svtplay-dl --only-audio -o /downloads https://www.svtplay.se/audio/...
+      OUTPUT_DIR: /downloads
 ```
+
+This makes the container’s `svtplay` user match the host UID/GID, which avoids permission mismatches on mounted volumes.
 
 ## GitHub Actions / GHCR
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
     image: docker-svtplay-dl:latest
     container_name: docker-svtplay-dl
     restart: unless-stopped

--- a/download.sh
+++ b/download.sh
@@ -9,7 +9,7 @@ if [ -f /tmp/svtplay-dl-commands.txt ]; then
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     echo "Running: $cmd"
-    sh -c "$cmd"
+    su-exec svtplay sh -c "$cmd"
   done < /tmp/svtplay-dl-commands.txt
   exit 0
 fi


### PR DESCRIPTION
Add host UID/GID mapping so the container user matches mounted host volume ownership, and keep svtplay-dl running as a non-root container user.