### PR TITLE
fix: align Plex refresh implementation and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,9 +95,9 @@ async function runCommands(config: Config, commands: string[], outputDir: string
       console.log(`Detected ${changedFiles.length} new/changed file(s) after command.`);
       try {
         await refreshPlex(
-          config,
           outputDir,
-          `New episodes were downloaded ${JSON.stringify(changedFiles)}`
+          config,
+          `New episodes where downloaded ${['\n', ...changedFiles].join('\n')}`
         );
       } catch (error) {
         console.error('Plex refresh failed:', error);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,45 @@
+import { HTTPError, RequestError, TimeoutError } from 'got';
+
+export function handleGotError(error: unknown, label: string, action: 'silence'): false;
+export function handleGotError(error: unknown, label: string, action: 'throw'): never;
+export function handleGotError(
+  error: unknown,
+  label: string,
+  action: 'silence' | 'throw'
+): false | never {
+  if (error instanceof HTTPError) {
+    const statusCode = error.response.statusCode;
+    const body = error.response.body;
+    const message = `API error while ${label}:${statusCode}: ${JSON.stringify(body)}`;
+    if (action === 'throw') {
+      throw new Error(message);
+    }
+    console.error(message);
+    return false;
+  }
+
+  if (error instanceof TimeoutError) {
+    const message = `Request timed out while ${label} at phase: ${error.event}`;
+    if (action === 'throw') {
+      throw new Error(message);
+    }
+    console.error(message);
+    return false;
+  }
+
+  if (error instanceof RequestError) {
+    const message = `Network error while ${label}:[${error.code}]: ${error.message}`;
+    if (action === 'throw') {
+      throw new Error(message);
+    }
+    console.error(message);
+    return false;
+  }
+
+  if (action === 'throw') {
+    console.error(error);
+    throw error;
+  }
+
+  return false;
+}

--- a/src/plex.spec.ts
+++ b/src/plex.spec.ts
@@ -1,7 +1,19 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { httpClient, refreshPlex } from './plex.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { refreshPlex } from './plex.js';
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const extendMock = vi.fn(() => ({ get: getMock, post: postMock }));
+
+vi.mock('got', () => ({
+  default: { extend: extendMock },
+  __esModule: true,
+}));
 
 const config = {
+  commands: [],
+  outputDir: '/tmp',
+  cronPattern: undefined,
   plexUrl: 'http://localhost',
   plexToken: 'test-token',
   plexSectionId: '1',
@@ -11,32 +23,39 @@ const config = {
 };
 
 describe('refreshPlex', () => {
+  beforeEach(() => {
+    extendMock.mockClear();
+    getMock.mockClear();
+    postMock.mockClear();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('refreshes Plex and sends a Pushover notification when refresh succeeds', async () => {
-    const getMock = vi.spyOn(httpClient, 'get');
-    const postMock = vi.spyOn(httpClient, 'post');
-
     getMock.mockResolvedValueOnce({ statusCode: 200 });
     postMock.mockResolvedValueOnce({ statusCode: 200 });
 
-    const result = await refreshPlex(config, '/downloads', 'fresh content');
+    const result = await refreshPlex('/downloads', config, 'The cause');
 
     expect(result).toBe(true);
-    expect(getMock).toHaveBeenCalledTimes(1);
-    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(extendMock).toHaveBeenCalledTimes(2);
+    expect(getMock).toHaveBeenCalledWith('library/sections/1/refresh', {
+      searchParams: { path: '/downloads' },
+    });
+    expect(postMock).toHaveBeenCalledWith(config.pushoverUrl, {
+      form: { title: 'yt-dlp -> Plex Refresh', message: 'The cause' },
+    });
   });
 
   it('skips Plex refresh when PLEX_TOKEN is missing', async () => {
-    const getMock = vi.spyOn(httpClient, 'get');
-    const postMock = vi.spyOn(httpClient, 'post');
     const partialConfig = { ...config, plexToken: undefined };
 
-    const result = await refreshPlex(partialConfig, '/downloads', 'fresh content');
+    const result = await refreshPlex('/downloads', partialConfig, 'The cause');
 
     expect(result).toBe(false);
+    expect(extendMock).not.toHaveBeenCalled();
     expect(getMock).not.toHaveBeenCalled();
     expect(postMock).not.toHaveBeenCalled();
   });

--- a/src/plex.ts
+++ b/src/plex.ts
@@ -1,118 +1,99 @@
-import got, { HTTPError } from 'got';
+import got from 'got';
+import type { Config } from './lib/config.js';
+import { handleGotError } from './lib/utils.js';
 
-export interface PlexConfig {
-  plexUrl: string;
-  plexToken?: string;
-  plexSectionId?: string;
+function createPlexClient(config: { plexUrl: string; plexToken: string }) {
+  return got.extend({
+    prefixUrl: config.plexUrl,
+    searchParams: { 'X-Plex-Token': config.plexToken },
+  });
+}
+
+function createPushoverClient(config: {
+  pushoverToken: string;
+  pushoverUser: string;
   pushoverUrl: string;
-  pushoverToken?: string;
-  pushoverUser?: string;
+}) {
+  return got.extend({
+    prefixUrl: config.pushoverUrl,
+    form: { token: config.pushoverToken, user: config.pushoverUser },
+  });
 }
 
-export const httpClient = got.extend({
-  headers: {
-    'user-agent': 'docker-svtplay-dl/0.1.0',
-  },
-  retry: {
-    limit: 2,
-    methods: ['GET', 'POST'],
-  },
-  throwHttpErrors: false,
-});
-
-async function fetchStatus(url: string, searchParams: Record<string, string>): Promise<number> {
-  try {
-    const response = await httpClient.get(url, { searchParams });
-    return response.statusCode ?? 0;
-  } catch (error: unknown) {
-    if (error instanceof HTTPError) {
-      throw new Error(`Failed Plex request to ${url}: ${error.response.statusCode}`, {
-        cause: error,
-      });
-    }
-
-    if (error instanceof Error) {
-      throw error;
-    }
-
-    throw new Error(`Failed Plex request to ${url}: ${String(error)}`, {
-      cause: error,
-    });
-  }
-}
-
-async function refreshSection(config: PlexConfig, label: string, path: string): Promise<boolean> {
-  if (!config.plexSectionId) {
-    console.log(`WARNING: PLEX_SECTION_ID missing, skipping Plex refresh for ${label}`);
+function validatePushoverConfig(
+  config: Config
+): config is Config & { pushoverToken: string; pushoverUser: string; pushoverUrl: string } {
+  if (!config.pushoverToken) {
+    console.log('WARNING: PUSHOVER_TOKEN missing, skipping notification');
     return false;
   }
-
-  const url = `${config.plexUrl}/library/sections/${config.plexSectionId}/refresh`;
-  const params: Record<string, string> = {
-    'X-Plex-Token': config.plexToken ?? '',
-  };
-  if (path) {
-    params.path = path;
+  if (!config.pushoverUser) {
+    console.log('WARNING: PUSHOVER_USER is missing, skipping notification');
+    return false;
   }
-  const status = await fetchStatus(url, params);
-
-  console.log(`Plex refresh HTTP status for ${label}: ${status}`);
-  if (status === 200 || status === 201 || status === 204) {
-    return true;
+  if (!config.pushoverUrl) {
+    console.log('WARNING: PUSHOVER_URL missing, skipping notification');
+    return false;
   }
-
-  console.log(`WARNING: Plex refresh request failed for ${label} (HTTP ${status})`);
-  return false;
+  return true;
 }
 
-async function notifyPushover(config: PlexConfig, message: string): Promise<void> {
-  if (!config.pushoverToken || !config.pushoverUser) {
+async function notifyPushover(message: string, config: Config): Promise<void> {
+  if (!validatePushoverConfig(config)) {
     return;
   }
 
-  const form = new URLSearchParams({
-    token: config.pushoverToken,
-    user: config.pushoverUser,
-    title: 'svtplay-dl -> Plex Refresh',
-    message,
-  });
+  const pushoverClient = createPushoverClient(config);
 
   try {
-    const response = await httpClient.post(config.pushoverUrl, {
-      form,
+    await pushoverClient.post(config.pushoverUrl, {
+      form: { title: 'yt-dlp -> Plex Refresh', message },
     });
 
-    if (response.statusCode === 200) {
-      console.log('Pushover notification sent');
-    } else {
-      console.log(`WARNING: Pushover notification failed (${response.statusCode})`);
-    }
+    console.log('Pushover notification sent');
   } catch (error: unknown) {
-    if (error instanceof HTTPError) {
-      console.log(`WARNING: Failed to send Pushover notification (${error.response.statusCode})`);
-      return;
-    }
-
-    const messageString = error instanceof Error ? error.message : String(error);
-    console.log(`WARNING: Failed to send Pushover notification (${messageString})`);
+    handleGotError(error, 'sending Pushover notification', 'silence');
   }
 }
 
-export async function refreshPlex(
-  config: PlexConfig,
-  downloadPath: string,
-  reason: string
-): Promise<boolean> {
+function validatePlexConfig(
+  config: Config
+): config is Config & { plexToken: string; plexSectionId: string; plexUrl: string } {
   if (!config.plexToken) {
     console.log('WARNING: PLEX_TOKEN missing, skipping Plex refresh');
     return false;
   }
+  if (!config.plexSectionId) {
+    console.log('WARNING: PLEX_SECTION_ID missing, skipping Plex refresh');
+    return false;
+  }
+  if (!config.plexUrl) {
+    console.log('WARNING: PLEX_URL missing, skipping Plex refresh');
+    return false;
+  }
+  return true;
+}
 
-  const success = await refreshSection(config, 'svtplay-dl', downloadPath || '');
+export async function refreshPlex(
+  downloadPath: string,
+  config: Config,
+  cause: string
+): Promise<boolean> {
+  if (!validatePlexConfig(config)) {
+    return false;
+  }
+  const plexClient = createPlexClient(config);
 
-  if (success) {
-    await notifyPushover(config, reason);
+  const searchParams = downloadPath ? { path: downloadPath } : {};
+
+  try {
+    const plexRefreshUrl = `library/sections/${config.plexSectionId}/refresh`;
+    const { statusCode } = await plexClient.get(plexRefreshUrl, { searchParams });
+    console.log(`Plex refresh HTTP status for Youtube: ${statusCode}`);
+  } catch (error: unknown) {
+    return handleGotError(error, 'refreshing Plex section', 'silence');
   }
 
-  return success;
+  await notifyPushover(cause, config);
+  return true;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -22,7 +22,7 @@ const optionalString = z
 
 export const envSchema = z
   .object({
-    SVTPLAY_DL_COMMANDS: parseCommands,
+    SVTPLAY_DL_COMMANDS: parseCommands.transform(value => value),
     OUTPUT_DIR: z.string().trim().default('/downloads'),
     CRON_PATTERN: optionalString,
     PLEX_URL: z.string().trim().url().default('http://plex:32400'),


### PR DESCRIPTION
- Updated Plex refresh helper to use got clients directly and validate config before refresh.
- Updated plex.spec.ts to mock got.extend and verify Plex/Pushover request parameters.
- Adjusted refreshPlex call usage in src/index.ts.